### PR TITLE
build: disable examples to compile with recent qt versions

### DIFF
--- a/qogon.pro
+++ b/qogon.pro
@@ -1,5 +1,5 @@
 TEMPLATE=subdirs
-SUBDIRS = src examples
+SUBDIRS = src
 
 examples.depends = src
 


### PR DESCRIPTION
Recent qt versions fail with the message when examples are enabled:

"You cannot build examples inside the Qt source tree, except as part of
a proper Qt build."